### PR TITLE
Don't add invalid buffers to marked array

### DIFF
--- a/autoload/ctrlp_bdelete.vim
+++ b/autoload/ctrlp_bdelete.vim
@@ -48,7 +48,7 @@ function! s:DeleteMarkedBuffers()
   let marked = ctrlp#getmarkedlist()
 
   " the file under the cursor is implicitly marked
-  if empty(marked)
+  if empty(marked) && ctrlp#getcline() != ''
     call add(marked, fnamemodify(ctrlp#getcline(), ':p'))
   endif
 


### PR DESCRIPTION
I found a bug wherein if you press `<c-@>` when the buffer list is empty, it causes a weird issue to occur where CtrlP takes over the entire screen.  

This should fix it by only adding the currently selected line to `marked` if `ctrlp#getcline()` evaluates to something other than an empty string.